### PR TITLE
Feature add filter to check for running instance

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -8,6 +8,8 @@ data "aws_vpc" "vpc" {
   count = var.vpc_id == null ? 1 : 0
 
   tags = local.vpc_data_lookup_tags
+
+  filter = local.vpc_running_instance_filter
 }
 
 data "aws_acm_certificate" "primary_acm_wildcard_cert" {

--- a/locals.tf
+++ b/locals.tf
@@ -12,6 +12,11 @@ locals {
     "environment" : var.environment
   }
 
+  vpc_running_instance_filter = {
+    name   = "instance-state-name"
+    values = ["running"]
+  }
+
   subnet_data_lookup_filters = var.subnet_data_lookup_filters != null ? var.subnet_data_lookup_filters : {
     "vpc-id" = [local.vpc_id]
     "tag:Name" = [


### PR DESCRIPTION
Add a filter to `data "aws_vpc" "vpc"` to only return running instances. The purpose of these changes is to prevent GitHub actions from failing when multiple actions may be running at the same time. 